### PR TITLE
Fix #60 - Synopsis crashes when file handling fails

### DIFF
--- a/Synopsis/Synopsis/AnalysisAndTranscodeOperation.h
+++ b/Synopsis/Synopsis/AnalysisAndTranscodeOperation.h
@@ -17,8 +17,12 @@
 @property (copy) NSMutableArray* analyzedAudioSampleBufferMetadata;
 @property (copy) NSDictionary* analyzedGlobalMetadata;
 
+@property (assign) BOOL succeeded;
+
 - (instancetype) initWithSourceURL:(NSURL*)sourceURL destinationURL:(NSURL*)destinationURL transcodeOptions:(NSDictionary*)transcodeOptions NS_DESIGNATED_INITIALIZER;
 
 - (instancetype) init NS_UNAVAILABLE;
+
+
 
 @end

--- a/Synopsis/Synopsis/AnalysisAndTranscodeOperation.m
+++ b/Synopsis/Synopsis/AnalysisAndTranscodeOperation.m
@@ -1066,12 +1066,13 @@
         
         // dealloc any analyzers now
         self.availableAnalyzers = nil;
-        
+		
+		self.succeeded = YES;
         [[LogController sharedLogController] appendSuccessLog:@"Finished Analysis Operation"];
     }
     else
     {
-        [[LogController sharedLogController] appendErrorLog:@"Unable to start transcode:"];
+        [[LogController sharedLogController] appendErrorLog:[NSString stringWithFormat:@"Unable to start transcode from %@ to %@:", self.sourceURL, self.destinationURL]];
         if(self.transcodeAssetReader.error)
         {
             [[LogController sharedLogController] appendErrorLog:[@"Read Error" stringByAppendingString:self.transcodeAssetReader.error.debugDescription]];
@@ -1080,6 +1081,7 @@
         {
             [[LogController sharedLogController] appendErrorLog:[@"Write Error" stringByAppendingString:self.transcodeAssetWriter.error.debugDescription]];
         }
+		self.succeeded = NO;
     }
 }
 

--- a/Synopsis/Synopsis/AppDelegate.m
+++ b/Synopsis/Synopsis/AppDelegate.m
@@ -302,34 +302,36 @@ static NSTimeInterval start;
                                 {
                                     // Retarded weak/strong pattern so we avoid retain loopl
                                     __strong AnalysisAndTranscodeOperation* strongAnalysis = weakAnalysis;
-                                    
-                                    NSDictionary* metadataOptions = @{kSynopsisAnalyzedVideoSampleBufferMetadataKey : strongAnalysis.analyzedVideoSampleBufferMetadata,
-                                                                      kSynopsisAnalyzedAudioSampleBufferMetadataKey : strongAnalysis.analyzedAudioSampleBufferMetadata,
-                                                                      kSynopsisAnalyzedGlobalMetadataKey : strongAnalysis.analyzedGlobalMetadata
-                                                                      };
-                                    
-                                    MetadataWriterTranscodeOperation* pass2 = [[MetadataWriterTranscodeOperation alloc] initWithSourceURL:destinationURL destinationURL:destinationURL2 metadataOptions:metadataOptions];
-                                    
-                                    pass2.completionBlock = (^(void)
-                                                             {
-                                                                 [[LogController sharedLogController] appendSuccessLog:@"Finished Analysis"];
-                                                                 
-                                                                 // Clean up
-                                                                 NSError* error;
-                                                                 if(![[NSFileManager defaultManager] removeItemAtURL:destinationURL error:&error])
-                                                                 {
-                                                                     [[LogController sharedLogController] appendErrorLog:[@"Error deleting temporary file: " stringByAppendingString:error.description]];
-                                                                 }
-                                                                 
-                                                                 
-                                                             });
-                                    
-                                    [self.metadataQueue addOperation:pass2];
-                                    
+									
+									if (strongAnalysis.succeeded) {
+										NSDictionary* metadataOptions = @{kSynopsisAnalyzedVideoSampleBufferMetadataKey : strongAnalysis.analyzedVideoSampleBufferMetadata,
+																		  kSynopsisAnalyzedAudioSampleBufferMetadataKey : strongAnalysis.analyzedAudioSampleBufferMetadata,
+																		  kSynopsisAnalyzedGlobalMetadataKey : strongAnalysis.analyzedGlobalMetadata
+																		  };
+										
+										MetadataWriterTranscodeOperation* pass2 = [[MetadataWriterTranscodeOperation alloc] initWithSourceURL:destinationURL destinationURL:destinationURL2 metadataOptions:metadataOptions];
+										
+										pass2.completionBlock = (^(void)
+																 {
+																	 [[LogController sharedLogController] appendSuccessLog:@"Finished Analysis"];
+																	 
+																	 // Clean up
+																	 NSError* error;
+																	 if(![[NSFileManager defaultManager] removeItemAtURL:destinationURL error:&error])
+																	 {
+																		 [[LogController sharedLogController] appendErrorLog:[@"Error deleting temporary file: " stringByAppendingString:error.description]];
+																	 }
+																	 
+																	 
+																 });
+										
+										[self.metadataQueue addOperation:pass2];
+									}
+									
                                 });
-    
+	
     [[LogController sharedLogController] appendVerboseLog:@"Begin Transcode and Analysis"];
-    
+	
     [self.transcodeQueue addOperation:analysis];
 }
 
@@ -340,21 +342,21 @@ static NSTimeInterval start;
     if(fileURLArray)
     {
         start = [NSDate timeIntervalSinceReferenceDate];
-        
+		
         for(NSURL* url in fileURLArray)
         {
             [self enqueueFileForTranscode:url];
         }
-        
+		
         NSBlockOperation* blockOp = [NSBlockOperation blockOperationWithBlock:^{
             NSTimeInterval delta = [NSDate timeIntervalSinceReferenceDate] - start;
-            
+			
             [[LogController sharedLogController] appendSuccessLog:[NSString stringWithFormat:@"Batch Took : %f seconds", delta]];
-            
+			
         }];
-        
+		
         [blockOp addDependency:[self.transcodeQueue.operations lastObject]];
-        
+		
         [self.transcodeQueue addOperation:blockOp];
     }
 }

--- a/Synopsis/Synopsis/MetadataWriterTranscodeOperation.m
+++ b/Synopsis/Synopsis/MetadataWriterTranscodeOperation.m
@@ -793,7 +793,7 @@
     }
     else
     {
-        [[LogController sharedLogController] appendErrorLog:@"Unable to start transcode:"];
+		[[LogController sharedLogController] appendErrorLog:[NSString stringWithFormat:@"Unable to start transcode from %@ to %@:", self.sourceURL, self.destinationURL]];
         [[LogController sharedLogController] appendErrorLog:[@"Read Error" stringByAppendingString:self.transcodeAssetReader.error.debugDescription]];
         [[LogController sharedLogController] appendErrorLog:[@"Write Error" stringByAppendingString:self.transcodeAssetWriter.error.debugDescription]];
     }


### PR DESCRIPTION
Add suceeded flag to AnalysisAndTranscodeOperation; don't proceed with metadata analysis if transcode fails; log filenames when transcode fails